### PR TITLE
Hide unstable top border due to subpixels

### DIFF
--- a/src/component/container/App/Subscription/SubscriptionContents/SubscriptionContentsContainer.css
+++ b/src/component/container/App/Subscription/SubscriptionContents/SubscriptionContentsContainer.css
@@ -59,6 +59,7 @@
     line-height: 1.5;
     padding: 0 1rem;
     border-bottom: 2px solid #a5c5ff;
+    margin-bottom: 1px;
 }
 
 /* Content body*/


### PR DESCRIPTION
Fix subpixel issue when using shortcut key `j` and `k`.

before:
![](https://i.gyazo.com/eb8687b9deb513fca71919c967d21d6b.gif)

after:
![](https://i.gyazo.com/7d223fafc4d98242953232597ac4f339.gif)