### PR TITLE
feat: add translate attributes to control browser translation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/src/component/ui-kit/HTMLContent.tsx
+++ b/src/component/ui-kit/HTMLContent.tsx
@@ -60,6 +60,7 @@ export class HTMLContent extends React.PureComponent<HTMLContentProps, {}> {
         return (
             <div
                 className={classnames("SubscriptionContentsContainer-contentBody", this.props.className)}
+                translate="yes"
                 dangerouslySetInnerHTML={{ __html: senitizedHTML }}
             />
         );


### PR DESCRIPTION
## Summary

Add HTML `translate` attributes to control browser auto-translation behavior. The root `<html>` element is marked with `translate="no"` to prevent translation of UI chrome, while the RSS content body (`HTMLContent`) is marked with `translate="yes"` to allow users to translate article content.

## Changes

- Add `translate="no"` to `<html>` element in `public/index.html`
- Add `translate="yes"` to the content body div in `src/component/ui-kit/HTMLContent.tsx`

## Breaking Changes

None

## Test Plan

- Open the app in a browser with auto-translate enabled (e.g., Chrome with a non-English language)
- Verify UI elements (buttons, labels) are not auto-translated
- Verify RSS article content can still be translated by the browser